### PR TITLE
Fixed multiple initialisation of the config options

### DIFF
--- a/src/main/java/com/sandymandy/pleasurecraft/freecam/FreeCamera.java
+++ b/src/main/java/com/sandymandy/pleasurecraft/freecam/FreeCamera.java
@@ -231,11 +231,11 @@ public class FreeCamera extends ClientPlayerEntity {
 
     @Override
     public void tickMovement() {
-        if (ModConfig.INSTANCE.movement.flightMode.equals(ModConfig.FlightMode.DEFAULT)) {
+        if (ModConfig.INSTANCE.freecamOptions.movement.flightMode.equals(ModConfig.FlightMode.DEFAULT)) {
             getAbilities().setFlySpeed(0);
-            Motion.doMotion(this, ModConfig.INSTANCE.movement.horizontalSpeed, ModConfig.INSTANCE.movement.verticalSpeed);
+            Motion.doMotion(this, ModConfig.INSTANCE.freecamOptions.movement.horizontalSpeed, ModConfig.INSTANCE.freecamOptions.movement.verticalSpeed);
         } else {
-            getAbilities().setFlySpeed((float) ModConfig.INSTANCE.movement.verticalSpeed / 10);
+            getAbilities().setFlySpeed((float) ModConfig.INSTANCE.freecamOptions.movement.verticalSpeed / 10);
         }
         super.tickMovement();
         getAbilities().flying = true;

--- a/src/main/java/com/sandymandy/pleasurecraft/freecam/Freecam.java
+++ b/src/main/java/com/sandymandy/pleasurecraft/freecam/Freecam.java
@@ -56,7 +56,7 @@ public class Freecam {
                 mc.player.input = input;
             }
 
-            mc.gameRenderer.setRenderHand(ModConfig.INSTANCE.visual.showHand);
+            mc.gameRenderer.setRenderHand(ModConfig.INSTANCE.freecamOptions.visual.showHand);
         }
     }
 
@@ -181,7 +181,7 @@ public class Freecam {
         MC.setCameraEntity(freeCamera);
         activeTripod = tripod;
 
-        if (ModConfig.INSTANCE.notification.notifyTripod) {
+        if (ModConfig.INSTANCE.freecamOptions.notification.notifyTripod) {
             MC.player.sendMessage(Text.translatable("msg.freecam.openTripod", tripod), true);
         }
     }
@@ -191,7 +191,7 @@ public class Freecam {
         onDisable();
 
         if (MC.player != null) {
-            if (ModConfig.INSTANCE.notification.notifyTripod) {
+            if (ModConfig.INSTANCE.freecamOptions.notification.notifyTripod) {
                 MC.player.sendMessage(Text.translatable("msg.freecam.closeTripod", activeTripod), true);
             }
         }
@@ -205,7 +205,7 @@ public class Freecam {
         freeCamera.spawn();
         MC.setCameraEntity(freeCamera);
 
-        if (ModConfig.INSTANCE.notification.notifyFreecam) {
+        if (ModConfig.INSTANCE.freecamOptions.notification.notifyFreecam) {
             MC.player.sendMessage(Text.translatable("msg.freecam.enable"), true);
         }
     }
@@ -214,7 +214,7 @@ public class Freecam {
         onDisable();
 
         if (MC.player != null) {
-            if (ModConfig.INSTANCE.notification.notifyFreecam) {
+            if (ModConfig.INSTANCE.freecamOptions.notification.notifyFreecam) {
                 MC.player.sendMessage(Text.translatable("msg.freecam.disable"), true);
             }
         }
@@ -222,7 +222,7 @@ public class Freecam {
 
     private static void onEnable() {
         MC.chunkCullingEnabled = false;
-        MC.gameRenderer.setRenderHand(ModConfig.INSTANCE.visual.showHand);
+        MC.gameRenderer.setRenderHand(ModConfig.INSTANCE.freecamOptions.visual.showHand);
 
         rememberedF5 = MC.options.getPerspective();
         if (MC.gameRenderer.getCamera().isThirdPerson()) {
@@ -257,7 +257,7 @@ public class Freecam {
             tripods.put(tripod, null);
         }
 
-        if (ModConfig.INSTANCE.notification.notifyTripod) {
+        if (ModConfig.INSTANCE.freecamOptions.notification.notifyTripod) {
             MC.player.sendMessage(Text.translatable("msg.freecam.tripodReset", tripod), true);
         }
     }
@@ -296,8 +296,8 @@ public class Freecam {
         }
         freeCamera.copyPositionAndRotation(MC.player);
         freeCamera.applyPerspective(
-                ModConfig.INSTANCE.visual.perspective,
-                ModConfig.INSTANCE.collision.alwaysCheck || !(ModConfig.INSTANCE.collision.ignoreAll)
+                ModConfig.INSTANCE.freecamOptions.visual.perspective,
+                ModConfig.INSTANCE.freecamOptions.collision.alwaysCheck || !(ModConfig.INSTANCE.freecamOptions.collision.ignoreAll)
         );
     }
 

--- a/src/main/java/com/sandymandy/pleasurecraft/freecam/config/CollisionBehavior.java
+++ b/src/main/java/com/sandymandy/pleasurecraft/freecam/config/CollisionBehavior.java
@@ -34,19 +34,19 @@ public class CollisionBehavior {
 
     @SuppressWarnings("RedundantIfStatement")
     public static boolean isIgnored(Block block) {
-        if (ModConfig.INSTANCE.collision.ignoreAll) {
+        if (ModConfig.INSTANCE.freecamOptions.collision.ignoreAll) {
             return true;
         }
 
-        if (ModConfig.INSTANCE.collision.ignoreTransparent && transparent.test(block)) {
+        if (ModConfig.INSTANCE.freecamOptions.collision.ignoreTransparent && transparent.test(block)) {
             return true;
         }
 
-        if (ModConfig.INSTANCE.collision.ignoreOpenable && openable.test(block)) {
+        if (ModConfig.INSTANCE.freecamOptions.collision.ignoreOpenable && openable.test(block)) {
             return true;
         }
 
-        if (ModConfig.INSTANCE.collision.ignoreCustom && custom.test(block)) {
+        if (ModConfig.INSTANCE.freecamOptions.collision.ignoreCustom && custom.test(block)) {
             return true;
         }
 
@@ -54,11 +54,11 @@ public class CollisionBehavior {
     }
 
     static ActionResult onConfigChange(ConfigHolder<ModConfig> holder, ModConfig config) {
-        String[] ids = config.collision.whitelist.ids.stream()
+        String[] ids = config.freecamOptions.collision.whitelist.ids.stream()
                 .map(id -> id.contains(":") ? id : "minecraft:" + id)
                 .toArray(String[]::new);
 
-        Pattern[] patterns = config.collision.whitelist.patterns.stream()
+        Pattern[] patterns = config.freecamOptions.collision.whitelist.patterns.stream()
                 .map(Pattern::compile)
                 .toArray(Pattern[]::new);
 

--- a/src/main/java/com/sandymandy/pleasurecraft/freecam/config/ModConfig.java
+++ b/src/main/java/com/sandymandy/pleasurecraft/freecam/config/ModConfig.java
@@ -33,7 +33,7 @@ public class ModConfig implements ConfigData {
     }
 
     @ConfigEntry.Gui.Tooltip
-    @ConfigEntry.Gui.CollapsibleObject(startExpanded = true)
+    @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
     public FreecamOptions freecamOptions = new FreecamOptions();
     public static class FreecamOptions {
         @ConfigEntry.Gui.CollapsibleObject
@@ -60,7 +60,6 @@ public class ModConfig implements ConfigData {
         private Object keys;
     }
 
-    public MovementConfig movement = new MovementConfig();
     public static class MovementConfig {
         @ConfigEntry.Gui.Tooltip
         @ConfigEntry.Gui.EnumHandler(option = EnumDisplayOption.BUTTON)
@@ -75,7 +74,6 @@ public class ModConfig implements ConfigData {
         public double verticalSpeed = 1.0;
     }
 
-    public CollisionConfig collision = new CollisionConfig();
     public static class CollisionConfig {
         @ConfigEntry.Gui.Tooltip
         public boolean ignoreTransparent = false;
@@ -102,7 +100,6 @@ public class ModConfig implements ConfigData {
         public boolean alwaysCheck = false;
     }
 
-    public VisualConfig visual = new VisualConfig();
     public static class VisualConfig {
         @ConfigEntry.Gui.Tooltip
         @ConfigEntry.Gui.EnumHandler(option = EnumDisplayOption.BUTTON)
@@ -121,7 +118,6 @@ public class ModConfig implements ConfigData {
         public boolean showSubmersion = false;
     }
 
-    public UtilityConfig utility = new UtilityConfig();
     public static class UtilityConfig {
         @ConfigEntry.Gui.Tooltip
         public boolean disableOnDamage = true;
@@ -134,8 +130,7 @@ public class ModConfig implements ConfigData {
         @ConfigEntry.Gui.EnumHandler(option = EnumDisplayOption.BUTTON)
         public InteractionMode interactionMode = InteractionMode.CAMERA;
     }
-
-    public NotificationConfig notification = new NotificationConfig();
+    
     public static class NotificationConfig {
         @ConfigEntry.Gui.Tooltip
         public boolean notifyFreecam = true;

--- a/src/main/java/com/sandymandy/pleasurecraft/mixins/BlockStateBaseMixin.java
+++ b/src/main/java/com/sandymandy/pleasurecraft/mixins/BlockStateBaseMixin.java
@@ -27,7 +27,7 @@ public abstract class BlockStateBaseMixin {
     private void onGetCollisionShape(BlockView world, BlockPos pos, ShapeContext context, CallbackInfoReturnable<VoxelShape> cir) {
         if (context instanceof EntityShapeContext entityShapeContext && entityShapeContext.getEntity() instanceof FreeCamera) {
             // Return early if "Always Check Initial Collision" is on and Freecam isn't enabled yet
-            if (ModConfig.INSTANCE.collision.alwaysCheck && !Freecam.isEnabled()) {
+            if (ModConfig.INSTANCE.freecamOptions.collision.alwaysCheck && !Freecam.isEnabled()) {
                 return;
             }
             // Otherwise, check the collision config

--- a/src/main/java/com/sandymandy/pleasurecraft/mixins/CameraMixin.java
+++ b/src/main/java/com/sandymandy/pleasurecraft/mixins/CameraMixin.java
@@ -36,7 +36,7 @@ public class CameraMixin {
     // Removes the submersion overlay when underwater, in lava, or powdered snow.
     @Inject(method = "getSubmersionType", at = @At("HEAD"), cancellable = true)
     public void onGetSubmersionType(CallbackInfoReturnable<CameraSubmersionType> cir) {
-        if (Freecam.isEnabled() && !ModConfig.INSTANCE.visual.showSubmersion) {
+        if (Freecam.isEnabled() && !ModConfig.INSTANCE.freecamOptions.visual.showSubmersion) {
             cir.setReturnValue(CameraSubmersionType.NONE);
         }
     }

--- a/src/main/java/com/sandymandy/pleasurecraft/mixins/EntityMixin.java
+++ b/src/main/java/com/sandymandy/pleasurecraft/mixins/EntityMixin.java
@@ -71,6 +71,6 @@ public class EntityMixin {
 
     @Unique
     private boolean freecam$allowFreeze() {
-        return ModConfig.INSTANCE.utility.freezePlayer && !Freecam.isPlayerControlEnabled();
+        return ModConfig.INSTANCE.freecamOptions.utility.freezePlayer && !Freecam.isPlayerControlEnabled();
     }
 }

--- a/src/main/java/com/sandymandy/pleasurecraft/mixins/GameRendererMixin.java
+++ b/src/main/java/com/sandymandy/pleasurecraft/mixins/GameRendererMixin.java
@@ -28,7 +28,7 @@ public class GameRendererMixin {
     @ModifyVariable(method = "findCrosshairTarget", at = @At("HEAD"), argsOnly = true)
     private Entity onUpdateTargetedEntity(Entity entity) {
         if (Freecam.isEnabled() && (Freecam.isPlayerControlEnabled()
-                || ModConfig.INSTANCE.utility.interactionMode.equals(ModConfig.InteractionMode.PLAYER))) {
+                || ModConfig.INSTANCE.freecamOptions.utility.interactionMode.equals(ModConfig.InteractionMode.PLAYER))) {
             return MC.player;
         }
         return entity;
@@ -38,6 +38,6 @@ public class GameRendererMixin {
 
     @Unique
     private static boolean freecam$allowInteract() {
-        return ModConfig.INSTANCE.utility.allowInteract && ModConfig.INSTANCE.utility.interactionMode.equals(PLAYER);
+        return ModConfig.INSTANCE.freecamOptions.utility.allowInteract && ModConfig.INSTANCE.freecamOptions.utility.interactionMode.equals(PLAYER);
     }
 }

--- a/src/main/java/com/sandymandy/pleasurecraft/mixins/LevelRendererMixin.java
+++ b/src/main/java/com/sandymandy/pleasurecraft/mixins/LevelRendererMixin.java
@@ -38,7 +38,7 @@ public abstract class LevelRendererMixin {
                           RenderTickCounter deltaTracker,
                           List<Entity> entities,
                           CallbackInfo ci) {
-        if (Freecam.isEnabled() && ModConfig.INSTANCE.visual.showPlayer) {
+        if (Freecam.isEnabled() && ModConfig.INSTANCE.freecamOptions.visual.showPlayer) {
             Vec3d position = camera.getPos();
             float partialTick = deltaTracker.getTickProgress(false);
             renderEntity(MC.player, position.x, position.y, position.z, partialTick, poseStack, bufferBuilders.getEntityVertexConsumers());

--- a/src/main/java/com/sandymandy/pleasurecraft/mixins/LightTextureMixin.java
+++ b/src/main/java/com/sandymandy/pleasurecraft/mixins/LightTextureMixin.java
@@ -13,7 +13,7 @@ public class LightTextureMixin {
 
     @WrapOperation(method = "update", at = @At(value = "INVOKE", target = "Ljava/lang/Double;floatValue()F", ordinal = 1))
     private float onSetBrightnessFactor(Double instance, Operation<Float> original) {
-        if (Freecam.isEnabled() && ModConfig.INSTANCE.visual.fullBright) {
+        if (Freecam.isEnabled() && ModConfig.INSTANCE.freecamOptions.visual.fullBright) {
             return Float.MAX_VALUE;
         }
         return original.call(instance);

--- a/src/main/java/com/sandymandy/pleasurecraft/mixins/LivingEntityMixin.java
+++ b/src/main/java/com/sandymandy/pleasurecraft/mixins/LivingEntityMixin.java
@@ -22,15 +22,15 @@ public abstract class LivingEntityMixin {
     // Allows for the horizontal speed of creative flight to be configured separately from vertical speed.
     @Inject(method = "getMovementSpeed()F", at = @At("HEAD"), cancellable = true)
     private void onGetMovementSpeed(CallbackInfoReturnable<Float> cir) {
-        if (Freecam.isEnabled() && ModConfig.INSTANCE.movement.flightMode.equals(CREATIVE) && this.equals(Freecam.getFreeCamera())) {
-            cir.setReturnValue((float) (ModConfig.INSTANCE.movement.horizontalSpeed / 10) * (Freecam.getFreeCamera().isSprinting() ? 2 : 1));
+        if (Freecam.isEnabled() && ModConfig.INSTANCE.freecamOptions.movement.flightMode.equals(CREATIVE) && this.equals(Freecam.getFreeCamera())) {
+            cir.setReturnValue((float) (ModConfig.INSTANCE.freecamOptions.movement.horizontalSpeed / 10) * (Freecam.getFreeCamera().isSprinting() ? 2 : 1));
         }
     }
 
     // Disables freecam upon receiving damage if disableOnDamage is enabled.
     @Inject(method = "setHealth", at = @At("HEAD"))
     private void onSetHealth(float health, CallbackInfo ci) {
-        if (Freecam.isEnabled() && ModConfig.INSTANCE.utility.disableOnDamage && this.equals(MC.player)) {
+        if (Freecam.isEnabled() && ModConfig.INSTANCE.freecamOptions.utility.disableOnDamage && this.equals(MC.player)) {
             if (!MC.player.isCreative() && getHealth() > health) {
                 Freecam.disableNextTick();
             }

--- a/src/main/java/com/sandymandy/pleasurecraft/mixins/MinecraftMixin.java
+++ b/src/main/java/com/sandymandy/pleasurecraft/mixins/MinecraftMixin.java
@@ -63,6 +63,6 @@ public class MinecraftMixin {
 
     @Unique
     private static boolean freecam$allowInteract() {
-        return ModConfig.INSTANCE.utility.allowInteract && ModConfig.INSTANCE.utility.interactionMode.equals(PLAYER);
+        return ModConfig.INSTANCE.freecamOptions.utility.allowInteract && ModConfig.INSTANCE.freecamOptions.utility.interactionMode.equals(PLAYER);
     }
 }

--- a/src/main/java/com/sandymandy/pleasurecraft/mixins/MultiPlayerGameModeMixin.java
+++ b/src/main/java/com/sandymandy/pleasurecraft/mixins/MultiPlayerGameModeMixin.java
@@ -63,6 +63,6 @@ public class MultiPlayerGameModeMixin {
 
     @Unique
     private static boolean freecam$allowInteract() {
-        return ModConfig.INSTANCE.utility.allowInteract && ModConfig.INSTANCE.utility.interactionMode.equals(PLAYER);
+        return ModConfig.INSTANCE.freecamOptions.utility.allowInteract && ModConfig.INSTANCE.freecamOptions.utility.interactionMode.equals(PLAYER);
     }
 }


### PR DESCRIPTION
the config options under freecam options were being called two times when accessing the freecam menu causing errors